### PR TITLE
Document Codex MCP server and include it in workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -753,6 +753,12 @@ custom tools:
 See the [MCP Server Integration guide](./docs/tools/mcp-server.md) for setup
 instructions.
 
+> 💡 **Use Gemini with Codex:** The repository includes a ready-to-run MCP server
+> for Codex in [`mcp-servers/gemini-codex-mcp`](./mcp-servers/gemini-codex-mcp).
+> Build it with `npm run build` and launch it via `npx gemini-codex-mcp` to make
+> Gemini available to Codex (and other MCP clients) through the
+> `gemini_generate_text` tool.
+
 ## 🤝 Contributing
 
 We welcome contributions! Gemini CLI is fully open source (Apache 2.0), and we

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   },
   "type": "module",
   "workspaces": [
-    "packages/*"
+    "packages/*",
+    "mcp-servers/*"
   ],
   "private": "true",
   "repository": {


### PR DESCRIPTION
## Summary
- include the mcp-servers packages in the root npm workspaces so installs and builds pick up the Codex server
- highlight the Gemini Codex MCP server in the README so Codex users can find setup instructions

## Testing
- npm run build --workspace gemini-codex-mcp-server

------
https://chatgpt.com/codex/tasks/task_e_690961417cf4832588d93e31295a3585

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds README guidance for the Gemini Codex MCP server and includes `mcp-servers/*` in root npm workspaces.
> 
> - **Documentation**:
>   - Update `README.md` to highlight the ready-to-run Gemini Codex MCP server in `mcp-servers/gemini-codex-mcp`, with build/run instructions and the `gemini_generate_text` tool.
> - **Build/Repo**:
>   - Extend root `package.json` `workspaces` to include `mcp-servers/*`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22fc7b5aeb53a9b7479ee0c9d5b66b508a11be5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->